### PR TITLE
Declare dependencies of the scripts in examples/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,11 @@ setup(
     install_requires=['M2Crypto', 'pyasn1>=0.1.7', 'pyasn1-modules'],
     test_suite='test',
     tests_require=[],
+    extras_require={
+        'u2f_server': ['WebOb'],
+        'u2f_server:python_version=="2.6"': ['argparse'],
+        'yubiauth_server': ['yubiauth', 'WebOb'],
+    },
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
This allows e.g. `pip install python-u2flib-server[u2f_server]` to get everything necessary to run examples/u2f_server.

The line containing `python_version=="2.6"` is an environment marker, supported since setuptools 0.7 (released June 2013). It doesn't interfere with builds/installs using e.g. setuptools 0.6.x on Ubuntu 12.04LTS. `argparse` is in the stdlib from Python 2.7.