### PR TITLE
Rebase of m2crypto -> cryptography migration 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 addons:
   apt:
     packages:
+      - libffi-dev
       - libssl-dev
       - python-dev
       - python-pip # Standin for python-setuptools, a build-dep of M2Crypto

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+* Version 4.0.0 (not yet released)
+ ** Major release: Changed backend from M2Crypto to cryptography
+ ** Added dependency on cryptography 1.2 or higher
+ ** Removed dependency on M2Crypto
+ ** utils.rand_bytes() now sources bytes from os.urandom()
+
 * Version 3.2.0 (released 2015-06-16)
  ** License change release: Changed license to BSD 2-clause.
 

--- a/README
+++ b/README
@@ -6,10 +6,15 @@ To read more about U2F and how to use a U2F library, visit
 link:http://developers.yubico.com/U2F[developers.yubico.com/U2F].
 
 === Dependencies
-u2flib-server depends on M2Crypto. On a Ubuntu system, this can be installed with
+u2flib-server depends on link:https://pypi.python.org/pypi/cryptography[cryptography],
+which requires libffi, OpenSSL, and a C compiler to build.
+On a Debian or Ubuntu system, the build dependencies can be installed with
 the following command: 
 
-  $ apt-get install python-m2crypto
+  $ sudo apt-get install build-essential libssl-dev libffi-dev python-dev
+
+For Windows the cryptography project provides prebuilt wheels.
+For other platforms refer to link:https://cryptography.io/en/stable/installation/[cryptography installation].
 
 === Installation
 u2flib-server is installable by running the following command:

--- a/test/test_matchers.py
+++ b/test/test_matchers.py
@@ -1,0 +1,46 @@
+import unittest
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+
+from u2flib_server.attestation.matchers import get_ext_by_oid
+
+YUBICO_ATTESTATION_CERT_SERIAL_544338083 = '''-----BEGIN CERTIFICATE-----
+MIICIjCCAQygAwIBAgIEIHHwozALBgkqhkiG9w0BAQswDzENMAsGA1UEAxMEdGVz
+dDAeFw0xNTA4MTEwOTAwMzNaFw0xNjA4MTAwOTAwMzNaMCkxJzAlBgNVBAMTHll1
+YmljbyBVMkYgRUUgU2VyaWFsIDU0NDMzODA4MzBZMBMGByqGSM49AgEGCCqGSM49
+AwEHA0IABPdFG1pBjBBQVhLrD39Qg1vKjuR2kRdBZnwLI/zgzztQpf4ffpkrkB/3
+E0TXj5zg8gN9sgMkX48geBe+tBEpvMmjOzA5MCIGCSsGAQQBgsQKAgQVMS4zLjYu
+MS40LjEuNDE0ODIuMS4yMBMGCysGAQQBguUcAgEBBAQDAgQwMAsGCSqGSIb3DQEB
+CwOCAQEAb3YpnmHHduNuWEXlLqlnww9034ZeZaojhPAYSLR8d5NPk9gc0hkjQKmI
+aaBM7DsaHbcHMKpXoMGTQSC++NCZTcKvZ0Lt12mp5HRnM1NNBPol8Hte5fLmvW4t
+Q9EzLl4gkz7LSlORxTuwTbae1eQqNdxdeB+0ilMFCEUc+3NGCNM0RWd+sP5+gzMX
+BDQAI1Sc9XaPIg8t3du5JChAl1ifpu/uERZ2WQgtxeBDO6z1Xoa5qz4svf5oURjP
+ZjxS0WUKht48Z2rIjk5lZzERSaY3RrX3UtrnZEIzCmInXOrcRPeAD4ZutpiwuHe6
+2ABsjuMRnKbATbOUiLdknNyPYYQz2g==
+-----END CERTIFICATE-----'''
+
+# From https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
+# Regsitered number     Enterprise
+# 1.3.6.1.4.1.41482     Yubico
+# 1.3.6.1.4.1.45724     FIDO Alliance, Inc.
+
+
+class X509ExtensionsTest(unittest.TestCase):
+
+    attestation_cert = x509.load_pem_x509_certificate(
+        YUBICO_ATTESTATION_CERT_SERIAL_544338083,
+        default_backend(),
+    )
+
+    def test_get_ext_by_oid_yubico(self):
+        self.assertEqual(
+            b'1.3.6.1.4.1.41482.1.2',
+            get_ext_by_oid(self.attestation_cert, '1.3.6.1.4.1.41482.2'),
+        )
+
+    def test_get_ext_by_oid_fido_alliance(self):
+        self.assertEqual(
+            b'\x03\x02\x040',
+            get_ext_by_oid(self.attestation_cert, '1.3.6.1.4.1.45724.2.1.1'),
+        )

--- a/u2flib_server/attestation/resolvers.py
+++ b/u2flib_server/attestation/resolvers.py
@@ -74,6 +74,12 @@ class MetadataResolver(object):
             self._metadata[cert] = metadata
 
     def _verify_cert(self, cert, key):
+        """Returns True if cert contains a correct signature made using the
+        provided key
+
+        NB: This *only* checks the signature. No other checks are performed.
+        E.g. the trust chain, expiry are all ignored.
+        """
         try:
             verify_cert_signature(cert, key)
             return True


### PR DESCRIPTION
This PR unifies the changes in https://github.com/moreati/python-u2flib-server/commits/cryptography and those applied in #17, it

- Fixes the CI build on Travis
- Updates the README and NEWS
- Adds a unit test for `u2flib_server.attestation.matchers.get_ext_by_oid()`

~~NB: Please don't merge this quite yet, there's a couple of parts I want to check still.~~