### PR TITLE
Fixes pep8 convention

### DIFF
--- a/u2flib_server/attestation/resolvers.py
+++ b/u2flib_server/attestation/resolvers.py
@@ -25,8 +25,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ['MetadataResolver', 'create_resolver']
-
 from u2flib_server.jsapi import MetadataObject
 from u2flib_server.attestation.data import YUBICO
 from u2flib_server.utils import verify_cert_signature
@@ -38,6 +36,8 @@ from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import NameOID
+
+__all__ = ['MetadataResolver', 'create_resolver']
 
 
 class MetadataResolver(object):


### PR DESCRIPTION
Imports were not at the top of the file, moves them to the top.

This matches the rest of the files now.
