### PR TITLE
Adding basic exception classes to provide more information on failures than ValueErrors.

### DIFF
--- a/u2flib_server/exceptions.py
+++ b/u2flib_server/exceptions.py
@@ -1,0 +1,35 @@
+class U2FClientDataValidationError(ValueError):
+    """Exception class used to indicate a failure
+    in the validation of client data errors.
+    Each property should have its own type, e.g.:
+
+    Wrong type:
+        - message: 'Wrong type! Was: <X>, expecting <Y>'
+        - property: 'type'
+
+    Wrong challenge:
+        - message: 'Wrong challenge! Was <X>, expecting <Y>'
+        - property: 'challenge'
+
+    Wrong facet:
+        - message: 'Wrong facet! Was <X>, expecting <Y>'
+        - property: 'facet'
+    """
+    def __init__(self, message, property):
+        super(U2FClientDataValidationError, self).__init__(message)
+        self.property = property
+
+class U2FSignatureError(ValueError):
+    """Exception class used to indicate a failure
+    validating the SignatureData of a request."""
+    pass
+
+class U2FSignRequestError(ValueError):
+    """Exception class used to indicate a failure
+    when signing a request."""
+    pass
+
+class U2FRegisterRequestError(ValueError):
+    """Exception class used to indicate a failure
+    when registering a device."""
+    pass


### PR DESCRIPTION
We use this library internally - it'd be great to have some sort of information on why verification events fail for a U2F request. 

This PR adds exception classes that can be utilized to provide extra information on failures.
For example: if the client data contains an incorrect challenge, a `U2FClientDataValidationError` can be raised with the `challenge` property, indicating to the server that the challenge was the reason for the failure. 
