### PR TITLE
Update the versions of Python used in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false
 
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy-5.4.1"
-  - "pypy3.3-5.2-alpha1"
+  - "3.7"
+  - "3.8"
+  - "pypy"
+  - "pypy3"
 
 cache:
   directories:


### PR DESCRIPTION
Python 3.3 and 3.4 are EOLed, and the versions of pypy and pypy3 were also too old. This adds support for current versions of Python in CI.