### PR TITLE
Support newer metdata formats

### DIFF
--- a/u2flib_server/attestation/matchers.py
+++ b/u2flib_server/attestation/matchers.py
@@ -66,11 +66,21 @@ class ExtensionMatcher(DeviceMatcher):
     def matches(self, certificate, parameters={}):
         key = parameters.get('key')
         match_value = parameters.get('value')
+
+        if isinstance(match_value, str):
+            match_value = match_value.encode('utf-8')
+
+        if isinstance(match_value, dict):
+            if match_value['type'] == 'hex':
+                match_value = bytes.fromhex(match_value['value'])
+            else:
+                return False
+
         extension_value = _get_ext_by_oid(certificate, key)
 
         return extension_value is not None and (
             match_value is None or
-            match_value.encode('utf-8') == extension_value
+            match_value == extension_value
         )
 
 


### PR DESCRIPTION
The latest version of the Yubico metadata available from: https://developers.yubico.com/U2F/yubico-metadata.json has introduced a new way to match on value, by allowing hex encoding:

```
{
          "type": "x509Extension",
          "parameters": {
            "key": "1.3.6.1.4.1.45724.1.1.4",
            "value": {
              "type": "hex",
              "value": "c5ef55ffad9a4b9fb580adebafe026d0"
            }
          }
        }
```

This quick pull request introduce support for this in the matchers.

I can however verify that my current Yubikey devices (Yubikey 5 NFC) is NOT correctly picked up with this change. My device has hex value `04102fc0579f811347eab116bb5a8db9202a` for `key`: `1.3.6.1.4.1.45724.1.1.4` but at least it doesn't barf anymore.